### PR TITLE
fix: validate user code has not expired

### DIFF
--- a/consent/handler.go
+++ b/consent/handler.go
@@ -1091,6 +1091,11 @@ func (h *Handler) acceptUserCodeRequest(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
+	if reqBody.UserCode == "" {
+		h.r.Writer().WriteError(w, r, errorsx.WithStack(fosite.ErrInvalidRequest.WithHint("Field 'user_code' must not be empty.")))
+		return
+	}
+
 	cr, err := h.r.ConsentManager().GetDeviceUserAuthRequest(ctx, challenge)
 	if err != nil {
 		h.r.Writer().WriteError(w, r, errorsx.WithStack(err))
@@ -1100,11 +1105,6 @@ func (h *Handler) acceptUserCodeRequest(w http.ResponseWriter, r *http.Request, 
 	f, err := flowctx.Decode[flow.Flow](ctx, h.r.FlowCipher(), challenge, flowctx.AsDeviceChallenge)
 	if err != nil {
 		h.r.Writer().WriteError(w, r, err)
-		return
-	}
-
-	if reqBody.UserCode == "" {
-		h.r.Writer().WriteError(w, r, errorsx.WithStack(fosite.ErrInvalidRequest.WithHint("Field 'user_code' must not be empty.")))
 		return
 	}
 

--- a/persistence/sql/persister_oauth2.go
+++ b/persistence/sql/persister_oauth2.go
@@ -613,6 +613,9 @@ func (p *Persister) CreateUserCodeSession(ctx context.Context, signature string,
 func (p *Persister) GetUserCodeSession(ctx context.Context, signature string, session fosite.Session) (_ fosite.Requester, err error) {
 	ctx, span := p.r.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.GetUserCodeSession")
 	defer otelx.End(span, &err)
+	if session == nil {
+		session = oauth2.NewSession("")
+	}
 	return p.findSessionBySignature(ctx, signature, session, sqlTableUserCode)
 }
 


### PR DESCRIPTION
IAM-820

Validate that the user code has not expired. Due to circular imports (the session object is defined in the `oauth2` package), I had to alter the persister logic to initialize the session, if a session object was not provided.