### PR TITLE
fix: post_device page

### DIFF
--- a/consent/strategy_oauth_test.go
+++ b/consent/strategy_oauth_test.go
@@ -1174,6 +1174,7 @@ func TestStrategyDeviceLoginConsent(t *testing.T) {
 			resp, err := hc.Get(devResp.VerificationURIComplete)
 			require.NoError(t, err)
 			require.Contains(t, reg.Config().DeviceDoneURL(ctx).String(), resp.Request.URL.Path, "did not end up in post device URL")
+			require.Equal(t, resp.Request.URL.Query().Get("client_id"), c.ID)
 
 			conf := oauth2Config(t, c)
 			_, err = conf.DeviceAccessToken(ctx, devResp)

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -771,7 +771,7 @@ func (h *Handler) performOAuth2DeviceVerificationFlow(w http.ResponseWriter, r *
 		}
 	}
 
-	redirectURL := urlx.SetQuery(h.c.DeviceDoneURL(ctx), url.Values{"consent_verifier": {string(f.ConsentVerifier)}}).String()
+	redirectURL := urlx.SetQuery(h.c.DeviceDoneURL(ctx), url.Values{"client_id": {f.Client.GetID()}}).String()
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -739,13 +739,20 @@ func (h *Handler) performOAuth2DeviceVerificationFlow(w http.ResponseWriter, r *
 		return
 	}
 
-	req := fosite.NewDeviceRequest()
-	req.Client = consentSession.ConsentRequest.Client
-	session, err := h.updateSessionWithRequest(ctx, consentSession, f, r, req)
+	// TODO(nsklikas): We need to add a db transaction here
+	req, err := h.r.OAuth2Storage().GetDeviceCodeSessionByRequestID(ctx, f.DeviceCodeRequestID.String(), &Session{})
+	if err != nil {
+		x.LogError(r, err, h.r.Logger())
+		h.r.Writer().WriteError(w, r, err)
+		return
+	}
+	// TODO(nsklika): Can we refactor this so we don't have to pass in the session?
+	session, err := h.updateSessionWithRequest(ctx, consentSession, f, r, req, req.GetSession().(*Session))
 	if err != nil {
 		h.r.Writer().WriteError(w, r, err)
 		return
 	}
+	session.SetBrowserFlowCompleted(true)
 
 	req.SetSession(session)
 	// Update the device code session with
@@ -1242,7 +1249,7 @@ func (h *Handler) oAuth2Authorize(w http.ResponseWriter, r *http.Request, _ http
 	}
 
 	authorizeRequest.SetID(acceptConsentSession.ID)
-	session, err := h.updateSessionWithRequest(ctx, acceptConsentSession, flow, r, authorizeRequest)
+	session, err := h.updateSessionWithRequest(ctx, acceptConsentSession, flow, r, authorizeRequest, nil)
 	if err != nil {
 		h.writeAuthorizeError(w, r, authorizeRequest, err)
 		return
@@ -1322,12 +1329,19 @@ func (h *Handler) writeAuthorizeError(w http.ResponseWriter, r *http.Request, ar
 
 // updateSessionWithRequest takes a session and a fosite.request as input and returns a new session.
 // If any errors occur, they are logged.
-func (h *Handler) updateSessionWithRequest(ctx context.Context, session *flow.AcceptOAuth2ConsentRequest, flow *flow.Flow, r *http.Request, request fosite.Requester) (*Session, error) {
-	for _, scope := range session.GrantedScope {
+func (h *Handler) updateSessionWithRequest(
+	ctx context.Context,
+	consent *flow.AcceptOAuth2ConsentRequest,
+	flow *flow.Flow,
+	r *http.Request,
+	request fosite.Requester,
+	session *Session,
+) (*Session, error) {
+	for _, scope := range consent.GrantedScope {
 		request.GrantScope(scope)
 	}
 
-	for _, audience := range session.GrantedAudience {
+	for _, audience := range consent.GrantedAudience {
 		request.GrantAudience(audience)
 	}
 
@@ -1346,7 +1360,7 @@ func (h *Handler) updateSessionWithRequest(ctx context.Context, session *flow.Ac
 		}
 	}
 
-	obfuscatedSubject, err := h.r.ConsentStrategy().ObfuscateSubjectIdentifier(ctx, request.GetClient(), session.ConsentRequest.Subject, session.ConsentRequest.ForceSubjectIdentifier)
+	obfuscatedSubject, err := h.r.ConsentStrategy().ObfuscateSubjectIdentifier(ctx, request.GetClient(), consent.ConsentRequest.Subject, consent.ConsentRequest.ForceSubjectIdentifier)
 	if e := &(fosite.RFC6749Error{}); errors.As(err, &e) {
 		x.LogAudit(r, err, h.r.AuditLogger())
 		return nil, err
@@ -1358,11 +1372,11 @@ func (h *Handler) updateSessionWithRequest(ctx context.Context, session *flow.Ac
 	claims := &jwt.IDTokenClaims{
 		Subject:                             obfuscatedSubject,
 		Issuer:                              h.c.IssuerURL(ctx).String(),
-		AuthTime:                            time.Time(session.AuthenticatedAt),
-		RequestedAt:                         session.RequestedAt,
-		Extra:                               session.Session.IDToken,
-		AuthenticationContextClassReference: session.ConsentRequest.ACR,
-		AuthenticationMethodsReferences:     session.ConsentRequest.AMR,
+		AuthTime:                            time.Time(consent.AuthenticatedAt),
+		RequestedAt:                         consent.RequestedAt,
+		Extra:                               consent.Session.IDToken,
+		AuthenticationContextClassReference: consent.ConsentRequest.ACR,
+		AuthenticationMethodsReferences:     consent.ConsentRequest.AMR,
 
 		// These are required for work around https://github.com/ory/fosite/issues/530
 		Nonce:    request.GetRequestForm().Get("nonce"),
@@ -1372,32 +1386,31 @@ func (h *Handler) updateSessionWithRequest(ctx context.Context, session *flow.Ac
 		// This is set by the fosite strategy
 		// ExpiresAt:   time.Now().Add(h.IDTokenLifespan).UTC(),
 	}
-	claims.Add("sid", session.ConsentRequest.LoginSessionID)
+	claims.Add("sid", consent.ConsentRequest.LoginSessionID)
 
-	s := &Session{
-		DefaultSession: &openid.DefaultSession{
-			Claims: claims,
-			Headers: &jwt.Headers{Extra: map[string]interface{}{
-				// required for lookup on jwk endpoint
-				"kid": openIDKeyID,
-			}},
-			Subject: session.ConsentRequest.Subject,
-		},
-		Extra:                 session.Session.AccessToken,
-		KID:                   accessTokenKeyID,
-		ClientID:              request.GetClient().GetID(),
-		ConsentChallenge:      session.ID,
-		ExcludeNotBeforeClaim: h.c.ExcludeNotBeforeClaim(ctx),
-		AllowedTopLevelClaims: h.c.AllowedTopLevelClaims(ctx),
-		MirrorTopLevelClaims:  h.c.MirrorTopLevelClaims(ctx),
-		Flow:                  flow,
+	if session == nil {
+		session = &Session{}
 	}
 
-	if _, ok := request.(*fosite.DeviceRequest); ok {
-		s.SetBrowserFlowCompleted(true)
+	if session.DefaultSession == nil {
+		session.DefaultSession = &openid.DefaultSession{}
 	}
+	session.DefaultSession.Claims = claims
+	session.DefaultSession.Headers = &jwt.Headers{Extra: map[string]interface{}{
+		// required for lookup on jwk endpoint
+		"kid": openIDKeyID,
+	}}
+	session.DefaultSession.Subject = consent.ConsentRequest.Subject
+	session.Extra = consent.Session.AccessToken
+	session.KID = accessTokenKeyID
+	session.ClientID = request.GetClient().GetID()
+	session.ConsentChallenge = consent.ID
+	session.ExcludeNotBeforeClaim = h.c.ExcludeNotBeforeClaim(ctx)
+	session.AllowedTopLevelClaims = h.c.AllowedTopLevelClaims(ctx)
+	session.MirrorTopLevelClaims = h.c.MirrorTopLevelClaims(ctx)
+	session.Flow = flow
 
-	return s, nil
+	return session, nil
 }
 
 func (h *Handler) logOrAudit(err error, r *http.Request) {

--- a/oauth2/oauth2_auth_code_test.go
+++ b/oauth2/oauth2_auth_code_test.go
@@ -1945,3 +1945,39 @@ func newOAuth2Client(
 		Scopes: strings.Split(c.Scope, " "),
 	}
 }
+
+func newDeviceClient(
+	t *testing.T,
+	reg interface {
+		config.Provider
+		client.Registry
+	},
+	opts ...func(*client.Client),
+) (*client.Client, *oauth2.Config) {
+	ctx := context.Background()
+	c := &client.Client{
+		GrantTypes: []string{
+			"refresh_token",
+			"urn:ietf:params:oauth:grant-type:device_code",
+		},
+		Scope:                   "hydra offline openid",
+		Audience:                []string{"https://api.ory.sh/"},
+		TokenEndpointAuthMethod: "none",
+	}
+
+	// apply options
+	for _, o := range opts {
+		o(c)
+	}
+
+	require.NoError(t, reg.ClientManager().CreateClient(ctx, c))
+	return c, &oauth2.Config{
+		ClientID: c.GetID(),
+		Endpoint: oauth2.Endpoint{
+			DeviceAuthURL: reg.Config().OAuth2DeviceAuthorisationURL(ctx).String(),
+			TokenURL:      reg.Config().OAuth2TokenURL(ctx).String(),
+			AuthStyle:     oauth2.AuthStyleInHeader,
+		},
+		Scopes: strings.Split(c.Scope, " "),
+	}
+}

--- a/persistence/sql/persister_oauth2.go
+++ b/persistence/sql/persister_oauth2.go
@@ -253,6 +253,29 @@ func (p *Persister) findSessionBySignature(ctx context.Context, signature string
 	return r.toRequest(ctx, session, p)
 }
 
+func (p *Persister) findSessionByRequestID(ctx context.Context, requestID string, session fosite.Session, table tableName) (fosite.Requester, error) {
+	r := OAuth2RequestSQL{Table: table}
+	err := p.QueryWithNetwork(ctx).Where("request_id = ?", requestID).First(&r)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, errorsx.WithStack(fosite.ErrNotFound)
+	}
+	if err != nil {
+		return nil, sqlcon.HandleError(err)
+	}
+	if !r.Active {
+		fr, err := r.toRequest(ctx, session, p)
+		if err != nil {
+			return nil, err
+		}
+		if table == sqlTableCode {
+			return fr, errorsx.WithStack(fosite.ErrInvalidatedAuthorizeCode)
+		}
+		return fr, errorsx.WithStack(fosite.ErrInactiveToken)
+	}
+
+	return r.toRequest(ctx, session, p)
+}
+
 func (p *Persister) deleteSessionBySignature(ctx context.Context, signature string, table tableName) error {
 	err := sqlcon.HandleError(
 		p.QueryWithNetwork(ctx).
@@ -609,6 +632,13 @@ func (p *Persister) GetDeviceCodeSession(ctx context.Context, signature string, 
 	ctx, span := p.r.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.GetDeviceCodeSession")
 	defer otelx.End(span, &err)
 	return p.findSessionBySignature(ctx, signature, session, sqlTableDeviceCode)
+}
+
+// GetDeviceCodeSessionByRequestID returns a device code session from the database
+func (p *Persister) GetDeviceCodeSessionByRequestID(ctx context.Context, requestID string, session fosite.Session) (_ fosite.Requester, err error) {
+	ctx, span := p.r.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.GetDeviceCodeSessionByRequestID")
+	defer otelx.End(span, &err)
+	return p.findSessionByRequestID(ctx, requestID, session, sqlTableDeviceCode)
 }
 
 // InvalidateDeviceCodeSession invalidates a device code session

--- a/x/fosite_storer.go
+++ b/x/fosite_storer.go
@@ -49,6 +49,7 @@ type FositeStorer interface {
 	// This is duplicated from Ory Fosite to help against deprecation linting errors.
 	DeleteOpenIDConnectSession(ctx context.Context, authorizeCode string) error
 
+	GetDeviceCodeSessionByRequestID(ctx context.Context, requestID string, requester fosite.Session) (fosite.Requester, error)
 	UpdateDeviceCodeSessionByRequestID(ctx context.Context, requestID string, requester fosite.Requester) error
 	UpdateAndInvalidateUserCodeSession(ctx context.Context, signature, challenge_id string) (err error)
 }


### PR DESCRIPTION
IAM-735

- Update the post device page query params.
- Fix bug were the device session data were over-written

The CI should pass once https://github.com/canonical/hydra/pull/10 is merged

TODO:
- [ ]  Move the session updating logic to another layer
- [ ] The `verify` endpoint persists the flow, fetches the device session, updates the device session. We need to add a transaction, but the handler is probably not the right place